### PR TITLE
Update meditation_timer.py

### DIFF
--- a/meditation_timer.py
+++ b/meditation_timer.py
@@ -16,9 +16,9 @@ __VERSION__ = "0.4.0"
 from os.path import join, dirname
 from time import time, sleep
 import argparse
-import pygame
 import sys
 import os
+import subprocess
 
 # Defining global variables
 if dirname(__file__) == "/usr/local/bin":
@@ -48,12 +48,7 @@ def wait(duration=0, debug_time=False):
 def play_chime():
     """Play a chime once
     """
-    pygame.mixer.init(frequency=44100)
-    pygame.mixer.music.load(DATA_PATH + "/bowl-short.ogg")
-    pygame.mixer.music.set_volume(args.volume)
-    pygame.mixer.music.play()
-    pygame.time.wait(8450)
-    pygame.mixer.quit()
+    subprocess.run(["mpv /usr/share/meditation-timer/data/dharma107.mp3 &>/dev/null & sleep 8"], shell=True)
 
 def play_chimes(n=1, debug_time=False):
     """Play a chime n times


### PR DESCRIPTION
Since I don't know any python, I wasn't sure how to make the variable for `sleep` a command option for the user, and I just went with the time that is most suitable for the chime sound I use, but if you know how to make it and it's not too complicated for you, it would be a nice addition as well.

Note also that in this case when `mpv` plays the new sound over the old one, the sound streams are combined, unlike how it worked with `pygame` where the old stream was interrupted. Personally I prefer this method, since some of the bell sounds are very long and so it sounds more realistic to hear the new strike combine with the weak wind-out in the background. When real bells are used, a new strike also interferes with the sound pattern from the previous strike; bells aren't usually silenced before a new strike.

This solution contains one bug though: the final end chime seems to be played only for the duration of `sleep` and is then abruptly stopped. It should play until the end of the file, but I couldn't figure out what was wrong.